### PR TITLE
2026年度サイト (/2026/) への対応

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 var USERNAME = "";
 var PASSWORD = "";
 var MAIL_RECEIVERS = "";
-var LOGIN_URL  = "https://moodle.fz.ocha.ac.jp/R7/login/index.php";
+var LOGIN_URL  = "https://moodle.fz.ocha.ac.jp/2026/login/index.php";
 
 // LINE用グローバル変数（スクリプトプロパティからloadParametersでロード）
 var LINE_CHANNEL_ID = "";
@@ -204,7 +204,7 @@ function loginAndGetCookies() {
     "followRedirects": true
   };
   Logger.log("【ホームページアクセス】リクエストに使用する Cookie: " + cookieString);
-  var homeResponse = UrlFetchApp.fetch("https://moodle.fz.ocha.ac.jp/R7/", homeOptions);
+  var homeResponse = UrlFetchApp.fetch("https://moodle.fz.ocha.ac.jp/2026/", homeOptions);
   var homeHeaders = homeResponse.getAllHeaders();
   Logger.log("ホームページアクセス時のレスポンスヘッダー: " + JSON.stringify(homeHeaders));
   mergeCookiesFromHeader(cookieStore, homeHeaders["Set-Cookie"]);


### PR DESCRIPTION
Closes #12

## Summary
- Moodle のサイトパス変更 (`/R7/` → `/2026/`) に追従
- `LOGIN_URL` とログイン後のホームページ URL のみハードコードされていたため更新
- ページ抽出ロジック (`extractPageContent` / `filterDynamicAttributes`) は変更不要

## 検証済み事項
`/2026/` 配下で `course/section.php?id=4557` を2回連続フェッチして比較：

| 段階 | 結果 |
|---|---|
| raw HTML | ❌ 不一致（ランダムIDが変動） |
| extractPageContent 後 | ❌ 不一致 |
| **filterDynamicAttributes 後** | ✅ **完全一致** |
| SHA-256 ハッシュ | ✅ 一致 |

→ 既存の動的属性フィルタが新サイトでもそのまま機能することを確認。

## Test plan
- [ ] URLCHECK シートの全URLを `/R7/` → `/2026/` に置換（運用作業）
- [ ] 初回 `main()` 実行で全ページが正常にフェッチ・ハッシュ計算されることを確認
- [ ] 数サイクル様子見し、誤検知（実際には更新されていないのに「更新」マークが付く）が発生しないか確認
- [ ] 万一誤検知が出た場合は本文中の `sesskey` 等動的文字列の有無を確認し `filterDynamicAttributes` を調整