### PR TITLE
自己回帰トリガーを廃止し時刻ガードで実行制御

### DIFF
--- a/main.js
+++ b/main.js
@@ -618,62 +618,16 @@ function doPost(e) {
 }
 
 //────────────────────────────────────────────
-// 次回実行トリガーの設定（既存機能）
-//────────────────────────────────────────────
-function scheduleNextExecution() {
-  // 既存の main 関数のトリガーをすべて削除
-  var allTriggers = ScriptApp.getProjectTriggers();
-  allTriggers.forEach(function(trigger) {
-    if (trigger.getHandlerFunction() === "main") {
-      ScriptApp.deleteTrigger(trigger);
-    }
-  });
-  
-  var now = new Date();
-  var nowMinutes = now.getHours() * 60 + now.getMinutes();
-  
-  // ターゲット時刻（分換算：7時から21時まで毎時）
-  var scheduledMinutes = [];
-  for (var hour = 7; hour <= 21; hour++) {
-    scheduledMinutes.push(hour * 60);
-  }
-  var targetTime = new Date(now);
-  var found = false;
-  
-  // 現在時刻より後の最初のターゲット時刻を今日中から探す
-  for (var i = 0; i < scheduledMinutes.length; i++) {
-    if (nowMinutes < scheduledMinutes[i]) {
-      var hour = Math.floor(scheduledMinutes[i] / 60);
-      var minute = scheduledMinutes[i] % 60;
-      targetTime.setHours(hour, minute, 0, 0);
-      found = true;
-      break;
-    }
-  }
-  
-  // 今日中に該当する時刻がなければ、翌日の7:00に設定
-  if (!found) {
-    targetTime = new Date(now);
-    targetTime.setDate(targetTime.getDate() + 1);
-    targetTime.setHours(7, 0, 0, 0);
-  }
-  
-  // 現在時刻とターゲット時刻の差分（ミリ秒）を算出
-  var msToWait = targetTime.getTime() - now.getTime();
-  
-  // 次回の実行トリガーを設定
-  ScriptApp.newTrigger("main")
-    .timeBased()
-    .after(msToWait)
-    .create();
-  
-  Logger.log("次回実行トリガーを " + targetTime.toString() + " に設定しました。");
-}
-
-//────────────────────────────────────────────
 // メイン実行関数（更新検知 → マスタ更新 → メール通知 → LINE通知）
 //────────────────────────────────────────────
 function main() {
+  // 実行時間帯ガード（7時～21時のみ実行）
+  var currentHour = new Date().getHours();
+  if (currentHour < 7 || currentHour > 21) {
+    Logger.log("実行時間帯外のためスキップしました（現在 " + currentHour + " 時）");
+    return;
+  }
+
   // loadConfig()で全設定を読み込む
   loadConfig();
 
@@ -732,9 +686,6 @@ function main() {
     sendUpdateEmail(updatedPages);
     sendLinePushNotifications(body);
   }
-  
-  // 次回実行トリガーを設定
-  scheduleNextExecution();
 }
 
 //────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `scheduleNextExecution()` を削除し、自己回帰トリガー方式から GAS の永続トリガー方式に移行
- 末尾の自己再予約呼び出しを削除し、`main()` 冒頭に7-21時の時刻ガードを追加

## 背景
従来は `main()` の末尾で `ScriptApp.newTrigger().after(ms)` により次回実行を1個ずつ予約する方式だった。この方式は途中で例外が発生すると次回トリガーが登録されず、以降の実行が完全に停止する脆弱性があった（実際に停止する事象が発生）。

GAS の時間ベーストリガーには「分ベースのタイマー」があり 1/5/10/15/30 分間隔の**永続**トリガーを設定できるため、こちらに切り替える。永続トリガーは個別の実行が失敗しても次回以降の発火に影響しないため、堅牢性が大きく向上する。あわせて従来1時間間隔だったチェック頻度を5分間隔程度まで上げられる利点もある。

## デプロイ手順（GAS 側の手動作業が必要）
1. GAS エディタの「トリガー」画面を開く
2. 既存の `main` トリガー（`after()` で予約された単発トリガー）を削除
3. 新規トリガーを作成:
   - 関数: `main`
   - イベントのソース: 時間主導型
   - 時間ベースのトリガーのタイプ: **分ベースのタイマー**
   - 時間の間隔: **5分おき**（運用に応じて調整可）

## Test plan
- [ ] GAS エディタで `main()` を手動実行し、7-21時の時間帯では従来通り動作することを確認
- [ ] 端末時刻を変更するか、深夜帯に実行されるトリガーで早期 return のログ（「実行時間帯外のためスキップしました」）が記録されることを確認
- [ ] 5分間隔の永続トリガー設置後、複数回の発火が継続することを確認
- [ ] わざと例外を発生させても、次回以降のトリガーが消えずに発火し続けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)